### PR TITLE
Gabriel new split teams refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store*
 .hubot_history
 .env
+.idea

--- a/scripts/pull-request-helper.js
+++ b/scripts/pull-request-helper.js
@@ -64,7 +64,7 @@ const prStructByUrL = async (url) => {
   })
 
   const prefixTaskCode = pullRequest.headRefName.match(TASK_PREFIXED_BRANCH_REGEX)
-    ? pullRequest.headRefName.replaceAll(TASK_PREFIXED_BRANCH_REGEX, '$1-$2')
+    ? pullRequest.headRefName.replaceAll(TASK_PREFIXED_BRANCH_REGEX, '$1')
     : ''
 
   return {

--- a/scripts/pull-requester.js
+++ b/scripts/pull-requester.js
@@ -3,8 +3,16 @@ dotenv.load()
 
 const pullRequestHelper = require('./pull-request-helper')
 
-const userMap = pullRequestHelper.userMap
-const SLACK_TO_GITHUB = Object.values(pullRequestHelper.userMap)
+function swapKeyValue(obj) {
+  var ret = {};
+  for(let key in obj){
+    ret[obj[key]] = key;
+  }
+  return ret;
+}
+
+const userMap = {...pullRequestHelper.userMap}
+const SLACK_TO_GITHUB = swapKeyValue(pullRequestHelper.userMap)
 
 const recycleReactionMatcher = (i) => {
   const isRecycle = (i.reaction === 'recycle')

--- a/scripts/pull-requester.js
+++ b/scripts/pull-requester.js
@@ -3,33 +3,12 @@ dotenv.load()
 
 const pullRequestHelper = require('./pull-request-helper')
 
-const userMap = {
-  variousauthors: '@andre',
-  stringbeans: '@john',
-  'austin-sa-wang': '@austin',
-  yoranl: '@yoran',
-  'gabriel-schmoeller': '@Schmoeller',
-  AndrewHui: '@andrew',
-  antonietapv: '@Toni',
-  chernandezbl: '@Cesar',
-  'dan22-book': '@Delgadillo ',
-}
-
-const SLACK_TO_GITHUB = {
-  andre: 'variousauthors',
-  john: 'stringbeans',
-  austin: 'austin-sa-wang',
-  yoran: 'yoranl',
-  Schmoeller: 'gabriel-schmoeller',
-  andrew: 'AndrewHui',
-  Toni: 'antonietapv',
-  Cesar: 'chernandezbl',
-  Delgadillo: 'dan22-book',
-}
+const userMap = pullRequestHelper.userMap
+const SLACK_TO_GITHUB = Object.values(pullRequestHelper.userMap)
 
 const recycleReactionMatcher = (i) => {
   const isRecycle = (i.reaction === 'recycle')
-  const isEd = (i.item_user && i.item_user.real_name.toLowerCase() == 'ed')
+  const isEd = (i.item_user && i.item_user.real_name.toLowerCase() === 'ed')
   return (isRecycle && isEd)
 }
 

--- a/scripts/pull-requester.js
+++ b/scripts/pull-requester.js
@@ -56,9 +56,12 @@ module.exports = (robot) => {
   populateSlacktoGithubUserMap(robot)
 
   robot.respond(/prs|(pull request status)/i, async (res) => {
-    const showAll = (res.message.text.includes('all'))
+    const args = res.message.text.replace(/.*?(prs|(pull request status))/i, '')
+      .trim()
+      .split(' ')
+      .filter(value => value !== '')
     const channelId = res.envelope.room
-    return pullRequestHelper.sendPullRequestsToChannel(robot, channelId, showAll)
+    return pullRequestHelper.sendPullRequestsToChannel(robot, channelId, args)
   })
 
   robot.listen(recycleReactionMatcher, (res) => {

--- a/scripts/queries/pull-requests.js
+++ b/scripts/queries/pull-requests.js
@@ -16,6 +16,9 @@ module.exports = {
       resource(url:"${url}"){
         ... on PullRequest {
           number
+          baseRefName
+          headRefName
+          isDraft
           repository {
             name
           }

--- a/scripts/queries/pull-requests.js
+++ b/scripts/queries/pull-requests.js
@@ -33,14 +33,12 @@ module.exports = {
               }
             }
           }
-          reviews(first:20) {
-            edges {
-              node {
-                state
-                submittedAt
-                author {
-                  login
-                }
+          reviews(last:50, states: [APPROVED, CHANGES_REQUESTED, DISMISSED]) {
+            nodes {
+              state
+              submittedAt
+              author {
+                login
               }
             }
           }


### PR DESCRIPTION
- Refactoring confusing and redundant codes
- Rearranging Ed messages
    - grouping PRs by teams (EDM, EDT, ...) and `Others`
    - removing everyone names list and focusing on the author only
    - adding a list of approvers and change requesters
    - sorting lists by authors
- Removing draft prs from the list